### PR TITLE
Pass meta data to block api call

### DIFF
--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -70,7 +70,7 @@ class Metadata {
                     ];
                     $blockMeta = [
                         'size' => $sizes[$matches[1]],
-                        'heading' => $matches[2],
+                        'heading' => $matches[2]['innerHTML'],
                     ];
                     break;
 

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -35,8 +35,12 @@ class RESTEndpoints {
         }
 
         $item_metadata = array();
-        $item_metadata['id'] = $post->ID;
-        $item_metadata['title'] = $post->post_title;
+
+        foreach( $post as $meta_key => $meta_value ) {
+            if ($meta_key != 'post_content') {
+                $item_metadata[$meta_key] = $meta_value;
+            }
+        }
 
         $block_data = Data::get_block_data($post->post_content);
         $block_metadata = Metadata::get_block_metadata($block_data);
@@ -65,8 +69,12 @@ class RESTEndpoints {
         $result = array();
         foreach($posts as $post) {
             $item_metadata = array();
-            $item_metadata['id'] = $post->ID;
-            $item_metadata['title'] = $post->post_title;
+
+            foreach( $post as $meta_key => $meta_value ) {
+                if ($meta_key != 'post_content') {
+                    $item_metadata[$meta_key] = $meta_value;
+                }
+            }
 
             $block_data = Data::get_block_data($post->post_content);
             $block_metadata = Metadata::get_block_metadata($block_data);


### PR DESCRIPTION
- I loop over all meta data fields and add them to the response, I strip out the post_content fields as that is the non block representation of the whole post, which we will not use.
- I stripped the html content from the heading block.