### PR TITLE
refactor: just pass query params through to get_posts call so we supp…

### DIFF
--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -56,7 +56,7 @@ class RESTEndpoints {
         $params = $request->get_params();
         $posts_per_page = $params['numberposts'];
         if (!isset($posts_per_page)) {
-			      $posts_per_page = 3000;
+	    $posts_per_page = 3000;
             $params['numberposts'] = $posts_per_page;
         }
 

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -55,7 +55,7 @@ class RESTEndpoints {
         $count_query = new \WP_Query();
         $count_query->query( array() );
         $total_posts  = $count_query->found_posts;
-        $total_pages = ceil( $total_posts / $posts_per_page );
+        $total_pages = ceil( $total_posts / count( $posts ) );
 
         $result = array();
         foreach($posts as $post) {

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -54,12 +54,18 @@ class RESTEndpoints {
     public static function get_all_post_block_meta($request)
     {
         $params = $request->get_params();
+        $posts_per_page = $params['numberposts'];
+        if (!isset($posts_per_page)) {
+			      $posts_per_page = 3000;
+            $params['numberposts'] = $posts_per_page;
+        }
+
         $posts = \get_posts($params);
 
         $count_query = new \WP_Query();
         $count_query->query( array() );
         $total_posts  = $count_query->found_posts;
-        $total_pages = ceil( $total_posts / count( $posts ) );
+        $total_pages = ceil( $total_posts / $posts_per_page );
 
         $result = array();
         foreach($posts as $post) {

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -56,7 +56,7 @@ class RESTEndpoints {
         $params = $request->get_params();
         $posts_per_page = $params['numberposts'];
         if (!isset($posts_per_page)) {
-	    $posts_per_page = 3000;
+            $posts_per_page = 3000;
             $params['numberposts'] = $posts_per_page;
         }
 

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -49,13 +49,8 @@ class RESTEndpoints {
 
     public static function get_all_post_block_meta($request)
     {
-        $posts_per_page = 3000;
-        $page = $request['page'];
-        $args = array(
-            'posts_per_page' => $posts_per_page,
-            'offset'         => $posts_per_page * $page,
-        );
-        $posts = \get_posts($args);
+        $params = $request->get_params();
+        $posts = \get_posts($params);
 
         $count_query = new \WP_Query();
         $count_query->query( array() );


### PR DESCRIPTION
I just pass all query parameters through to the get_posts call, so we support the same parameters as the get_posts call.